### PR TITLE
DEV: various improvements

### DIFF
--- a/assets/javascripts/discourse/components/reviewable-field-user.js.es6
+++ b/assets/javascripts/discourse/components/reviewable-field-user.js.es6
@@ -2,11 +2,13 @@ import Component from "@ember/component";
 
 export default Component.extend({
   actions: {
-    userChanged(previouslySelected, selected) {
+    userChanged(selectedUsername) {
+      this.set("value", selectedUsername[0]);
+
       this.valueChanged &&
         this.valueChanged({
           target: {
-            value: selected[0],
+            value: selectedUsername[0],
           },
         });
     },

--- a/assets/javascripts/discourse/templates/components/reviewable-field-user.hbs
+++ b/assets/javascripts/discourse/templates/components/reviewable-field-user.hbs
@@ -1,6 +1,9 @@
-<label>{{i18n 'change_owner.title'}}</label>
-{{user-selector 
-  usernames=value 
-  single=true 
-  onChangeCallback=(action "userChanged")
-  excludeCurrentUser=true}}
+<label>{{i18n "change_owner.title"}}</label>
+{{email-group-user-chooser
+  value=value
+  options=(hash
+    maximum=1
+  )
+  onChange=(action "userChanged")
+  includeStagedUsers=true
+}}

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # name: discourse-change-owner
-# about: Allow staff to change post owner in the review queue 
+# about: Allow staff to change post owner in the review queue
 # version: 0.1
 # author: Faizaan Gagan
 # url: https://github.com/paviliondev/discourse-change-owner


### PR DESCRIPTION
- Replaces the depricated `user-selector` with `email-group-user-chooser`
- Adds support to list staged users in review queue subject to the discourse PR https://github.com/discourse/discourse/pull/13201 being merged
- Fixes client and server side linting issues.